### PR TITLE
Prevent a crash when the save file is empty (#16)

### DIFF
--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/SaveFileHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/SaveFileHelper.java
@@ -338,6 +338,12 @@ public class SaveFileHelper {
 
             String setlistContent  = SaveFileHelper.openFile(context, setlist);
 
+            if (setlistContent.length() == 0) {
+                message.obj = new String[0];
+                asyncHandler.sendMessage(message);
+                return;
+            }
+
             String[] files = setlistContent.split("\n");
 
             ArrayList<String> existingFiles = SaveFileHelper.getExistingFiles(context, files);


### PR DESCRIPTION
This fixes #16 by returning early in case the save file is empty. Running `.split("\n")` produces an array with one element, which is `null`. As a consequence, executing `.replace()` on `null` causes a crash.