### PR TITLE
No Ticket: Escape single quotes in French translation to fix build failure

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,9 +68,9 @@
     <string name="first_run_message">\n<b>Quoi de neuf dans la version 2.1.4 ?</b>\n\n
         <li>ChangeLog ajouté à F-droid</li>\n
         <li>Extraction Web: extrait maintenant le BPM si fourni</li>\n
-        <li>Correction de bug: enregistrer la setlist uniquement lorsqu'il est modifié</li>\n
-        <li>Correction de bugs: attraper des pointeurs nuls pendant que Wakelock acquérir et restaurer l'application à partir de l'arrière-plan</li>\n
-        <li>Correction de bugs: améliorer l'extraction Web - Correction des espaces blancs perdus après plusieurs nouvelles lignes</li>\n
+        <li>Correction de bug: enregistrer la setlist uniquement lorsqu\'il est modifié</li>\n
+        <li>Correction de bugs: attraper des pointeurs nuls pendant que Wakelock acquérir et restaurer l\'application à partir de l\'arrière-plan</li>\n
+        <li>Correction de bugs: améliorer l\'extraction Web - Correction des espaces blancs perdus après plusieurs nouvelles lignes</li>\n
         \nChord Reader 2 est un <b>logiciel open source</b>.\n</string>
     <string name="unsaved_changes">Modifications non enregistrées</string>
     <string name="unsaved_changes_message">Voulez-vous enregistrer vos modifications?</string>


### PR DESCRIPTION
# Introduction

The `'` need to be escaped (cp. the other translations).
Without the escaping, the build fails.

## How to test

1. Checkout `master`
2. Open Android Studio and try to run the app on the emulator

The build will fail and the app will not run.

Now, checkout this pull request's branch and try the same again. The build should succeed.

## Additional note

@AndInTheClouds, I would assume that the build fails for the folks over at F-Droid as well, which could also be part of the reason that the new version is not available yet. We probably need to create a new tag.