### PR TITLE
Use artist and title from UG for the filename

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,11 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion '1.3.2'
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -54,6 +59,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.9'
 }
 
 

--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/MetadataExtractionHelper.kt
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/MetadataExtractionHelper.kt
@@ -1,0 +1,31 @@
+package org.hollowbamboo.chordreader2.helper
+
+import android.net.Uri
+
+class MetadataExtractionHelper {
+    fun extractSuggestedFilename(url: String, html: String): String? {
+        val uri = Uri.parse(url)
+
+        if (uri.host == ULTIMATE_GUITAR_HOST) {
+            return getFilenameFromUltimateGuitarHTML(html)
+        }
+
+        return null
+    }
+
+    private fun getFilenameFromUltimateGuitarHTML(html: String): String? {
+        val pattern = "<meta property=\"og:title\" content=\"([^\"]+) \\(Chords\\)".toRegex()
+        val matchResult = pattern.find(html) ?: return null
+
+        val groupValues = matchResult.groupValues
+        if (groupValues.isEmpty()) {
+            return null
+        }
+
+        return groupValues[1]
+    }
+
+    companion object {
+        const val ULTIMATE_GUITAR_HOST = "tabs.ultimate-guitar.com"
+    }
+}

--- a/app/src/main/java/org/hollowbamboo/chordreader2/model/WebSearchViewModel.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/model/WebSearchViewModel.java
@@ -16,6 +16,7 @@ import androidx.lifecycle.ViewModel;
 import org.hollowbamboo.chordreader2.ChordWebpage;
 import org.hollowbamboo.chordreader2.chords.NoteNaming;
 import org.hollowbamboo.chordreader2.chords.regex.ChordParser;
+import org.hollowbamboo.chordreader2.helper.MetadataExtractionHelper;
 import org.hollowbamboo.chordreader2.helper.WebPageExtractionHelper;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -142,6 +143,17 @@ public class WebSearchViewModel extends ViewModel {
 //		}
 
         return chordText;
+    }
+
+    public String getSuggestedFilename() {
+        MetadataExtractionHelper extractionHelper = new MetadataExtractionHelper();
+        String suggestedFilenameFromHTML = extractionHelper.extractSuggestedFilename(url, html);
+
+        if (suggestedFilenameFromHTML != null) {
+            return suggestedFilenameFromHTML;
+        }
+
+        return searchText;
     }
 
     public boolean checkHtmlOfUnknownWebpage() {

--- a/app/src/main/java/org/hollowbamboo/chordreader2/ui/WebSearchFragment.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/ui/WebSearchFragment.java
@@ -492,7 +492,7 @@ public class WebSearchFragment extends Fragment implements TextView.OnEditorActi
                     String chordText = editText.getText().toString();
 
                     WebSearchFragmentDirections.ActionNavWebSearchToNavSongView action =
-                            WebSearchFragmentDirections.actionNavWebSearchToNavSongView(webSearchViewModel.getSearchText(), chordText);
+                            WebSearchFragmentDirections.actionNavWebSearchToNavSongView(webSearchViewModel.getSuggestedFilename(), chordText);
                     action.setBpm(webSearchViewModel.getBPM());
                     if (getParentFragment() != null) {
                         Navigation.findNavController(getParentFragment().requireView()).navigate(action);

--- a/app/src/test/java/org/hollowbamboo/chordreader2/MetadataExtractionHelperTest.kt
+++ b/app/src/test/java/org/hollowbamboo/chordreader2/MetadataExtractionHelperTest.kt
@@ -1,0 +1,54 @@
+package org.hollowbamboo.chordreader2
+
+import android.net.Uri
+import org.hollowbamboo.chordreader2.helper.MetadataExtractionHelper
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+public class MetadataExtractionHelperTest {
+    @Test
+    fun extractSuggestedFilename_when_notUltimateGuitarHost_should_returnNull() {
+        // Given
+        val url = "https://example.com"
+
+        // When
+        val actual = MetadataExtractionHelper().extractSuggestedFilename(url, "")
+
+        // Then
+        Assert.assertNull(actual)
+    }
+
+    @Test
+    fun extractSuggestedFilename_when_ultimateGuitarHost_butNoOGTitleMetaTag_should_returnNull() {
+        // Given
+        val url = "https://${MetadataExtractionHelper.ULTIMATE_GUITAR_HOST}"
+        val html = ""
+
+        // When
+        val actual = MetadataExtractionHelper().extractSuggestedFilename(url, html)
+
+        // Then
+        Assert.assertNull(actual)
+    }
+
+    @Test
+    fun extractSuggestedFilename_when_ultimateGuitarHost_andOGTitleMetaTagPresent_should_returnTheContent() {
+        // Given
+        val url = "https://${MetadataExtractionHelper.ULTIMATE_GUITAR_HOST}"
+        val metaTagContent = "Lorem ipsum dolor sit"
+        val html = """
+        <meta property="og:type" content="music.song">
+        <meta property="og:title" content="$metaTagContent (Chords)">
+        <meta property="og:description" content="CHORDS foo bar">
+        """.trimIndent()
+
+        // When
+        val actual = MetadataExtractionHelper().extractSuggestedFilename(url, html)
+
+        // Then
+        Assert.assertEquals(metaTagContent, actual)
+    }
+}


### PR DESCRIPTION
With this branch, the app will use the content of Ultimate Guitar's "og:title" meta tag to suggest a better filename. It's a first step for the implementation of #27.

Take a look at the result:

<img width="387" alt="Screenshot 2023-08-02 at 13 26 33" src="https://github.com/AndInTheClouds/chordreader2/assets/1681085/366c1016-af80-433a-88af-638579446725">

The first two songs have been imported using this branch, whereas the last two items used the `searchText` that I entered when looking for the songs.

The newly added `MetadataExtractionHelper` can be extended to support more pages in the future. The extraction is also covered with unit tests. I needed to add [Roboelectric](https://robolectric.org/) to be able to use `Uri` in the unit test.