### PR TITLE
Allow for transpose settings to be changed by tapping text views

### DIFF
--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/DialogHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/DialogHelper.java
@@ -1,7 +1,11 @@
 package org.hollowbamboo.chordreader2.helper;
 
+import static java.lang.Integer.max;
+import static java.lang.Integer.min;
+
 import android.content.Context;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
@@ -37,11 +41,14 @@ public class DialogHelper {
 	}
 
 	private static void setUpEnhancedSeekBar(View view, final int min, int max, int defaultValue) {
-		
+		SeekBar seekBar = (SeekBar) view.findViewById(R.id.seek_bar_main);
 		TextView minTextView = (TextView) view.findViewById(R.id.seek_bar_min_text_view);
 		TextView maxTextView = (TextView) view.findViewById(R.id.seek_bar_max_text_view);
+
+		setupOnTouchListenerForTextViewToChangeSeekBarProgress(minTextView, seekBar, -1, min, max);
+		setupOnTouchListenerForTextViewToChangeSeekBarProgress(maxTextView, seekBar, +1, min, max);
+
 		final TextView progressTextView = (TextView) view.findViewById(R.id.seek_bar_main_text_view);
-		SeekBar seekBar = (SeekBar) view.findViewById(R.id.seek_bar_main);
 		
 		minTextView.setText(Integer.toString(min));
 		// check if we need to distinguish between negative and positive
@@ -76,6 +83,35 @@ public class DialogHelper {
 		});
 		seekBar.setProgress(defaultValue - min); // initialize to default value
 		
+	}
+
+	private static void setupOnTouchListenerForTextViewToChangeSeekBarProgress(
+			final TextView textView,
+			SeekBar seekBar,
+			final int change,
+			final int minimumValue,
+			final int maximumValue
+	) {
+		textView.setOnTouchListener((view, motionEvent) -> {
+			if (motionEvent.getAction() == MotionEvent.ACTION_DOWN) {
+				updateSeekBarProgress(seekBar, change, minimumValue, maximumValue);
+			}
+			return false;
+		});
+	}
+
+	private static void updateSeekBarProgress(
+			SeekBar seekBar,
+			final int change,
+			final int minimumValue,
+			final int maximumValue
+	) {
+		int currentValue = seekBar.getProgress() + minimumValue;
+
+		// Make sure the new value does not exceed the bounds
+		int newValue = min(maximumValue, max(minimumValue, currentValue + change));
+
+		seekBar.setProgress(newValue - minimumValue);
 	}
 	
 }


### PR DESCRIPTION
This change allows users to not only use the `SeekBar` when changing the transpose settings, but also to tap on the "min" and "max" `TextView`s:

<img width="314" alt="transpose-dialog" src="https://github.com/AndInTheClouds/chordreader2/assets/1681085/f8d4107e-cf02-42bf-b65f-f7279c31c6b3">

From my experience, it can be difficult to select the correct "progress" for the `SeekBar` when dragging and dropping. Tapping the `TextView`s to in- or decrease the values by 1 should be much easier.