### PR TITLE
Introduce "Automatic" color scheme that follows the system's "Night Mode"

### DIFF
--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
@@ -3,7 +3,9 @@ package org.hollowbamboo.chordreader2.helper;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.content.res.Configuration;
 import android.net.Uri;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import org.hollowbamboo.chordreader2.R;
 import org.hollowbamboo.chordreader2.chords.NoteNaming;
@@ -43,17 +45,31 @@ public class PreferenceHelper {
 	public static ColorScheme getColorScheme(Context context) {
 		
 		if(colorScheme == null) {
-		
+			String automaticColorSchemeName = context.getText(R.string.pref_scheme_system).toString();
 			SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 			String colorSchemeName = sharedPrefs.getString(
 					context.getText(R.string.pref_scheme).toString(), 
 					context.getText(ColorScheme.Dark.getNameResource()).toString());
-			
-			colorScheme = ColorScheme.findByPreferenceName(colorSchemeName, context);
+
+			if (colorSchemeName.equals(automaticColorSchemeName)) {
+				colorScheme = isNightModeActive(context) ? ColorScheme.Dark : ColorScheme.Light;
+			} else {
+				colorScheme = ColorScheme.findByPreferenceName(colorSchemeName, context);
+			}
 		}
 		
 		return colorScheme;
-		
+	}
+
+	private static boolean isNightModeActive(Context context) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			return context.getResources().getConfiguration().isNightModeActive();
+		} else {
+			int nightModeFlags = context.getResources().getConfiguration().uiMode &
+					Configuration.UI_MODE_NIGHT_MASK;
+
+			return nightModeFlags == Configuration.UI_MODE_NIGHT_YES;
+		}
 	}
 
 	public static NoteNaming getNoteNaming(Context context) {

--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
@@ -49,7 +49,7 @@ public class PreferenceHelper {
 			SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 			String colorSchemeName = sharedPrefs.getString(
 					context.getText(R.string.pref_scheme).toString(), 
-					context.getText(ColorScheme.Dark.getNameResource()).toString());
+					automaticColorSchemeName);
 
 			if (colorSchemeName.equals(automaticColorSchemeName)) {
 				colorScheme = isNightModeActive(context) ? ColorScheme.Dark : ColorScheme.Light;

--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
@@ -13,13 +13,11 @@ import org.hollowbamboo.chordreader2.data.ColorScheme;
 
 public class PreferenceHelper {
 
-	private static ColorScheme colorScheme = null;
 	private static NoteNaming noteNaming = null;
 	private static String searchEngineURL = null;
 	private static String storageLocation = null;
 
 	public static void clearCache() {
-		colorScheme = null;
 		noteNaming = null;
 		searchEngineURL = null;
 		storageLocation = null;
@@ -53,19 +51,14 @@ public class PreferenceHelper {
 	}
 	
 	public static ColorScheme getColorScheme(Context context) {
-		
-		if(colorScheme == null) {
-			String automaticColorSchemeName = context.getText(R.string.pref_scheme_system).toString();
-			String colorSchemeName = getColorSchemeName(context);
+		String automaticColorSchemeName = context.getText(R.string.pref_scheme_system).toString();
+		String colorSchemeName = getColorSchemeName(context);
 
-			if (colorSchemeName.equals(automaticColorSchemeName)) {
-				colorScheme = isNightModeActive(context) ? ColorScheme.Dark : ColorScheme.Light;
-			} else {
-				colorScheme = ColorScheme.findByPreferenceName(colorSchemeName, context);
-			}
+		if (colorSchemeName.equals(automaticColorSchemeName)) {
+			return isNightModeActive(context) ? ColorScheme.Dark : ColorScheme.Light;
+		} else {
+			return ColorScheme.findByPreferenceName(colorSchemeName, context);
 		}
-		
-		return colorScheme;
 	}
 
 	private static boolean isNightModeActive(Context context) {

--- a/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/helper/PreferenceHelper.java
@@ -41,15 +41,22 @@ public class PreferenceHelper {
 		return sharedPrefs.getBoolean(context.getString(R.string.pref_first_run), true);
 
 	}
+
+	public static String getColorSchemeName(Context context) {
+		String automaticColorSchemeName = context.getText(R.string.pref_scheme_system).toString();
+		SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		return sharedPrefs.getString(
+				context.getText(R.string.pref_scheme).toString(),
+				automaticColorSchemeName
+		);
+	}
 	
 	public static ColorScheme getColorScheme(Context context) {
 		
 		if(colorScheme == null) {
 			String automaticColorSchemeName = context.getText(R.string.pref_scheme_system).toString();
-			SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
-			String colorSchemeName = sharedPrefs.getString(
-					context.getText(R.string.pref_scheme).toString(), 
-					automaticColorSchemeName);
+			String colorSchemeName = getColorSchemeName(context);
 
 			if (colorSchemeName.equals(automaticColorSchemeName)) {
 				colorScheme = isNightModeActive(context) ? ColorScheme.Dark : ColorScheme.Light;

--- a/app/src/main/java/org/hollowbamboo/chordreader2/ui/SettingsFragment.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/ui/SettingsFragment.java
@@ -98,7 +98,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
         themePreference = findPreference(getString(R.string.pref_scheme));
         themePreference.setOnPreferenceChangeListener(this);
 
-        CharSequence themeSummary = getString(PreferenceHelper.getColorScheme(requireContext()).getNameResource());
+        String themeSummary = PreferenceHelper.getColorSchemeName(requireContext());
         themePreference.setSummary(themeSummary);
 
         noteNamingPreference = findPreference(getString(R.string.pref_note_naming));

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,6 +1,7 @@
 <resources>
 
 	<string-array name="color_schemes">
+		<item>@string/pref_scheme_system</item>
 		<item>@string/pref_scheme_dark</item>
 		<item>@string/pref_scheme_light</item>
 		<item>@string/pref_scheme_android</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
 
     <string name="pref_scheme" translatable="false">color_scheme</string>
     <string name="pref_scheme_title">Color Scheme</string>
+    <string name="pref_scheme_system" translatable="false">Automatic</string>
     <string name="pref_scheme_dark" translatable="false">Dark</string>
     <string name="pref_scheme_light" translatable="false">Light</string>
     <string name="pref_scheme_android" translatable="false">Android</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -6,7 +6,7 @@
 		<ListPreference android:key="@string/pref_scheme"
 			android:title="@string/pref_scheme_title" android:persistent="true"
 			android:entries="@array/color_schemes" android:entryValues="@array/color_schemes"
-			android:defaultValue="@string/pref_scheme_dark" />	
+			android:defaultValue="@string/pref_scheme_system" />
 				
 	</PreferenceCategory>
 	


### PR DESCRIPTION
This branch adds a new option for the color theme, "Automatic", which is selected by default. 

<img width="343" alt="color-scheme-automatic" src="https://github.com/AndInTheClouds/chordreader2/assets/1681085/89854940-60a8-40df-b49c-b4dc757211b8">

With this new option enabled, the app's color theme will take Android's "Night Mode" into account: If Night Mode was active, the `ColorScheme.Dark` is used. If it was not (or is not available), `ColorScheme.Light` is used.

Users can still opt to use one of the already existing color schemes if they wanted. With this new option, however, the app feels more like it is following the user's preference.