### PR TITLE
Keep the song screen on

### DIFF
--- a/app/src/main/res/layout/fragment_song_view.xml
+++ b/app/src/main/res/layout/fragment_song_view.xml
@@ -12,7 +12,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/chords_viewing_main_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:keepScreenOn="true">
 
 
         <org.hollowbamboo.chordreader2.views.AutoScrollView


### PR DESCRIPTION
In the screen where the song is displayed, keep the screen on. For other screens, the default timeout is used as always.

I was troubled when the song screen was first dimmed and then turned off while I was reading the chart. This PR addresses that by setting a Layout attribute that tells Android to not shut off the screen while the layout in question is in focus.
