### PR TITLE
Keep screen turned on on chord activity

### DIFF
--- a/app/src/main/res/layout/fragment_song_view.xml
+++ b/app/src/main/res/layout/fragment_song_view.xml
@@ -12,7 +12,9 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/chords_viewing_main_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:keepScreenOn="true"
+        >
 
 
         <org.hollowbamboo.chordreader2.views.AutoScrollView


### PR DESCRIPTION
The most annoying thing that can happen when playing a song is the screen turning off in the middle of it.

This will keep the screen active, but only on the chord sheet.