### PR TITLE
Add keyboard arrow key support to scroll

### DIFF
--- a/app/src/main/java/org/hollowbamboo/chordreader2/views/AutoScrollView.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/views/AutoScrollView.java
@@ -297,24 +297,31 @@ public class AutoScrollView extends ScrollView {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        // Handle arrow keys to pause/resume autoscroll, just like touch events
+        // Handle arrow keys with scrolling for bluetooth control devices (e.g. STOMP foot pedals)
         int action = event.getAction();
         int keyCode = event.getKeyCode();
         
-        // Check if it's an arrow key
         if (keyCode == KeyEvent.KEYCODE_DPAD_UP || 
-            keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
-            keyCode == KeyEvent.KEYCODE_DPAD_LEFT || 
-            keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+            keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
             
             if (action == KeyEvent.ACTION_DOWN) {
-                // Key pressed - pause autoscroll like touch down
                 this.isTouched = true;
                 if(this.isAutoScrollOn()) {
                     this.stopAutoScroll();
                 }
+                
+                final int SCROLL_AMOUNT = 200;
+                if (keyCode == KeyEvent.KEYCODE_DPAD_UP) {
+                    smoothScrollBy(0, -SCROLL_AMOUNT);
+                } else if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+                    smoothScrollBy(0, SCROLL_AMOUNT);
+                }
+                // Left/Right arrows do nothing
+                
+                return true; // Consume the event - prevent default behavior
+                
             } else if (action == KeyEvent.ACTION_UP) {
-                // Key released - resume autoscroll like touch up
+                // Key released - resume autoscroll after animation completes
                 this.isTouched = false;
                 if(this.isAutoScrollOn()) {
                     this.postDelayed(new Runnable() {
@@ -326,8 +333,9 @@ public class AutoScrollView extends ScrollView {
                                 AutoScrollView.this.startAutoScroll();
                             }
                         }
-                    }, 100);
+                    }, 250);
                 }
+                return true;
             }
         }
         

--- a/app/src/main/java/org/hollowbamboo/chordreader2/views/AutoScrollView.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/views/AutoScrollView.java
@@ -20,6 +20,7 @@ If not, see <https://www.gnu.org/licenses/>.
 import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.widget.ScrollView;
 import android.widget.TextView;
@@ -292,6 +293,45 @@ public class AutoScrollView extends ScrollView {
             super.onTouchEvent(event);
         }
         return false;
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        // Handle arrow keys to pause/resume autoscroll, just like touch events
+        int action = event.getAction();
+        int keyCode = event.getKeyCode();
+        
+        // Check if it's an arrow key
+        if (keyCode == KeyEvent.KEYCODE_DPAD_UP || 
+            keyCode == KeyEvent.KEYCODE_DPAD_DOWN ||
+            keyCode == KeyEvent.KEYCODE_DPAD_LEFT || 
+            keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+            
+            if (action == KeyEvent.ACTION_DOWN) {
+                // Key pressed - pause autoscroll like touch down
+                this.isTouched = true;
+                if(this.isAutoScrollOn()) {
+                    this.stopAutoScroll();
+                }
+            } else if (action == KeyEvent.ACTION_UP) {
+                // Key released - resume autoscroll like touch up
+                this.isTouched = false;
+                if(this.isAutoScrollOn()) {
+                    this.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            if(!AutoScrollView.this.isFlingActive() && 
+                               AutoScrollView.this.isAutoScrollOn() && 
+                               !AutoScrollView.this.isAutoScrollActive()) {
+                                AutoScrollView.this.startAutoScroll();
+                            }
+                        }
+                    }, 100);
+                }
+            }
+        }
+        
+        return super.dispatchKeyEvent(event);
     }
 
 


### PR DESCRIPTION
## Description
Adds keyboard arrow key functionality to manually scroll

## Changes
- Implemented `dispatchKeyEvent()` in `AutoScrollView` to handle arrow keys
- Up/Down arrows scroll 200 pixels with smooth animation
- Autoscroll pauses on key press and resumes after 250ms delay

## Testing
- Tested on Pixel 6 Pro and Samsung Galaxy Tab S8 using keyboard and STOMP bluetooth pedal
- Works seamlessly with autoscroll feature
- No conflicts with touch scrolling behavior

This was a requested feature as per [issue #64](https://github.com/AndInTheClouds/chordreader2/issues/64)
