### PR TITLE
refactor(websearch): isolate the WebView JS bridge in a small inner class

### DIFF
--- a/app/src/main/java/org/hollowbamboo/chordreader2/ui/WebSearchFragment.java
+++ b/app/src/main/java/org/hollowbamboo/chordreader2/ui/WebSearchFragment.java
@@ -221,7 +221,7 @@ public class WebSearchFragment extends Fragment implements TextView.OnEditorActi
         webView.restoreState(getArguments().getBundle("webViewState"));
 
         webView.getSettings().setJavaScriptEnabled(true);
-        webView.addJavascriptInterface(this, "HTMLOUT");
+        webView.addJavascriptInterface(new HtmlBridge(), "HTMLOUT");
 
         ScaleGestureDetector scaleGestureDetector = new ScaleGestureDetector(requireContext(), new MyScaleListener());
 
@@ -370,16 +370,19 @@ public class WebSearchFragment extends Fragment implements TextView.OnEditorActi
         webView.loadUrl(url);
     }
 
-    @SuppressWarnings("unused")
-    @JavascriptInterface
-    public void showHTML(String html) {
+    private final class HtmlBridge {
 
-        Log.d(LOG_TAG,"html is %s..." + (html != null ? (html.substring(0, Math.min(html.length(), 30))) : null));
+        @SuppressWarnings("unused")
+        @JavascriptInterface
+        public void showHTML(String html) {
 
-        webSearchViewModel.setHtml(html);
+            Log.d(LOG_TAG, "html is %s..." + (html != null ? (html.substring(0, Math.min(html.length(), 30))) : null));
 
-        handler.post(this::urlAndHtmlLoaded);
+            webSearchViewModel.setHtml(html);
 
+            handler.post(WebSearchFragment.this::urlAndHtmlLoaded);
+
+        }
     }
 
     private void urlAndHtmlLoaded() {


### PR DESCRIPTION
Closes #70.

\`WebSearchFragment.setUpWebView()\` passes itself as the JS bridge:

\`\`\`java
webView.addJavascriptInterface(this, \"HTMLOUT\");
\`\`\`

and the bridge method \`showHTML\` lives on the Fragment.

Only \`@JavascriptInterface\`-annotated methods are reachable from JS on API 17+, so this is not a security regression on currently supported Android. But binding the bridge to the Fragment couples the WebView lifecycle to the Fragment lifecycle (the WebView holds a reference to the Fragment object for the bridge), and any future method on \`WebSearchFragment\` is silently promoted to the JS surface the moment someone adds \`@JavascriptInterface\` to it.

### Change

Move \`showHTML\` into a small private \`HtmlBridge\` inner class and hand an instance of that to \`addJavascriptInterface\`. JS contract is unchanged (\`window.HTMLOUT.showHTML(html)\`), behaviour is unchanged, and the bridge surface is now intent-limited and easy to audit.